### PR TITLE
fix display of errors during page initialization

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -67,7 +67,7 @@ export default class HabitTrackerPlugin extends Plugin {
 
     //@ts-ignore
     window.renderHabitCalendar = (el: HTMLElement, dv: any, calendarParam: CalendarParam): void => {
-      const filepath = dv.current().file.path
+      const filepath = dv?.current()?.file?.path
       let calendarData = param2CalendarData(dv, calendarParam)
       let ctx = fromCalendarData(calendarData, this.settings)
 
@@ -125,7 +125,7 @@ function param2CalendarData(dv: any, params: CalendarParam): CalendarData {
   const calendarData: CalendarData = {
     year: params.year,
     month: params.month,
-    filepath: dv.current().file.path,
+    filepath: dv?.current()?.file?.path,
     width: params.width || "100%",
     entries: params.data,
     format: params.format || 'text',


### PR DESCRIPTION
When the calendar page first loads, errors flicker for a fraction of a second

![0](https://github.com/user-attachments/assets/547474fe-d342-41e8-89f7-6c3c71c9dc20)
![1](https://github.com/user-attachments/assets/23ca101d-5bf9-4e24-a06b-72cbb07b4f38)
